### PR TITLE
Ignore errors when collecting names for completion

### DIFF
--- a/docker-tramp.el
+++ b/docker-tramp.el
@@ -74,7 +74,8 @@
   "Collect docker running containers.
 
 Return a list of containers of the form: \(ID NAME\)"
-  (cl-loop for line in (cdr (apply #'process-lines docker-tramp-docker-executable (append docker-tramp-docker-options (list "ps"))))
+  (cl-loop for line in (cdr (ignore-errors
+			      (apply #'process-lines docker-tramp-docker-executable (append docker-tramp-docker-options (list "ps")))))
            for info = (split-string line "[[:space:]]+" t)
            collect (cons (car info) (last info))))
 


### PR DESCRIPTION
If the Docker container you want to access is on a remote machine (using Tramp's multi-hop syntax, e.g. `/ssh:user@host|docker:abc123:`), but the local machine doesn't have the "docker" binary, then completion would signal an error, which would abort the minibuffer prompt when opening a file.

With this change, errors from "docker ps" are silently ignored, thus enabling the use of remote Docker containers, though without name completion.