### PR TITLE
Add note to header doc comment about tramp-remote-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ overwrites `tramp-wait-for-output` with the patch applied:
 
         (require 'docker-tramp-compat)
 
+### Tramp does not respect remote `PATH`
+
+This is a known issue with Tramp, but is not a bug so much as a poor default
+setting.  Adding `tramp-own-remote-path` to `tramp-remote-path` will make
+Tramp use the remote's `PATH` environment varialbe.
+
+        (add-to-list 'tramp-remote-path 'tramp-own-remote-path)
+
 [Multi-hop]: https://www.gnu.org/software/emacs/manual/html_node/tramp/Ad_002dhoc-multi_002dhops.html
 [98a5112]: http://git.savannah.gnu.org/cgit/tramp.git/commit/?id=98a511248a9405848ed44de48a565b0b725af82c
 [docker-tramp-compat.el]: https://github.com/emacs-pe/docker-tramp.el/raw/master/docker-tramp-compat.el

--- a/docker-tramp.el
+++ b/docker-tramp.el
@@ -67,6 +67,14 @@
 ;;
 ;;     (require 'docker-tramp-compat)
 ;;
+;; ### Tramp does not respect remote `PATH'
+;;
+;; This is a known issue with Tramp, but is not a bug so much as a poor default
+;; setting.  Adding `tramp-own-remote-path' to `tramp-remote-path' will make
+;; Tramp use the remote's `PATH' environment varialbe.
+;;
+;;     (add-to-list 'tramp-remote-path 'tramp-own-remote-path)
+;;
 ;; [Multi-hop]: https://www.gnu.org/software/emacs/manual/html_node/tramp/Ad_002dhoc-multi_002dhops.html
 ;; [98a5112]: http://git.savannah.gnu.org/cgit/tramp.git/commit/?id=98a511248a9405848ed44de48a565b0b725af82c
 ;; [docker-tramp-compat.el]: https://github.com/emacs-pe/docker-tramp.el/raw/master/docker-tramp-compat.el


### PR DESCRIPTION
The issue was raised in #8 but never documented.  This note in the "Troubleshooting" section should save other users time.