### PR TITLE
Customization of docker-tramp-docker-executable updates tramp-methods

### DIFF
--- a/docker-tramp.el
+++ b/docker-tramp.el
@@ -164,6 +164,19 @@ to connect to the default user containers."
                  (tramp-remote-shell       "/bin/sh")
                  (tramp-remote-shell-args  ("-i" "-c")))))
 
+(defun docker-tramp--update-method ()
+  "Update docker tramp method."
+  (let (it)
+    (while (setq it (assoc docker-tramp-method tramp-methods))
+      (setq tramp-methods (delq it tramp-methods))))
+  (docker-tramp-add-method))
+
+;; Customization of `docker-tramp-docker-executable' updates `docker-tramp-method'
+(put 'docker-tramp-docker-executable 'custom-set
+     (lambda (sym val)
+       (custom-set-default sym val)
+       (docker-tramp--update-method)))
+
 ;;;###autoload
 (eval-after-load 'tramp
   '(progn


### PR DESCRIPTION
At creation, `docker-tramp-method` uses the value of
`docker-tramp-docker-executable`;  after a customization of the later,
the former still refers to the old executable.

Instead, ensure a customization of the executable also updates
the tramp method.
